### PR TITLE
Fix error in rust example code.

### DIFF
--- a/features/log.html
+++ b/features/log.html
@@ -212,14 +212,14 @@ builds, an easy way to achieve it is using conditional compilation on
 <pre><pre class="playground"><code class="language-rust"><span class="boring">#![allow(unused)]
 </span><span class="boring">fn main() {
 </span>// this code is compiled only if debug assertions are enabled (debug mode)
-#![cfg(debug_assertions)]
+#[(debug_assertions)]
 app.insert_resource(LogSettings {
     filter: &quot;info,wgpu_core=warn,wgpu_hal=warn,minewars=debug&quot;.into(),
     level: bevy::log::Level::DEBUG,
 });
 
 // this code is compiled only if debug assertions are disabled (release mode)
-#![cfg(not(debug_assertions))]
+#[cfg(not(debug_assertions))]
 app.insert_resource(LogSettings {
     filter: &quot;warn&quot;.into(),
     level: bevy::log::Level::WARN,


### PR DESCRIPTION
The fixed code threw the error
```bash
error: an inner attribute is not permitted in this context
   --> src/main.rs:66:5
    |
 66 |     #![cfg(debug_assertions)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: inner attributes, like `#![no_std]`, annotate the item enclosing them,
  and are usually found at the beginning of source files
    = note: outer attributes, like `#[test]`, annotate the item following them
 
 error: could not compile `snake` due to previous error
```